### PR TITLE
Include Kafka record metadata in deserialization error message

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
@@ -53,7 +53,13 @@ public class KafkaRecordEmitter<T>
             deserializationSchema.deserialize(consumerRecord, sourceOutputWrapper);
             splitState.setCurrentOffset(consumerRecord.offset() + 1);
         } catch (Exception e) {
-            throw new IOException("Failed to deserialize consumer record due to", e);
+            throw new IOException(
+                    String.format(
+                            "Failed to deserialize consumer record from topic=%s, partition=%d, offset=%d due to",
+                            consumerRecord.topic(),
+                            consumerRecord.partition(),
+                            consumerRecord.offset()),
+                    e);
         }
     }
 


### PR DESCRIPTION
When `KafkaRecordEmitter.emitRecord()` catches a deserialization exception, the error message is generic:

```
java.io.IOException: Failed to deserialize consumer record due to
    at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:57)
    at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:33)
    at org.apache.flink.connector.base.source.reader.SourceReaderBase.pollNext(SourceReaderBase.java:164)
```

This provides no information about which record caused the failure, making debugging difficult in production environments with many topics and partitions.

This change includes topic, partition, and offset in the exception message:

```
java.io.IOException: Failed to deserialize consumer record from topic=my-topic, partition=117, offset=448550177 due to
    at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:57)
    at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:33)
    at org.apache.flink.connector.base.source.reader.SourceReaderBase.pollNext(SourceReaderBase.java:164)
```

